### PR TITLE
bump react version in package.json to support react v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "gulp-babel": "^6.1.1",
     "gulp-util": "^3.0.7",
     "should": "^8.1.1",
-    "react": "^0.14.6",
-    "react-dom": "^0.14.6"
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1"
   },
   "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
+    "react": "15.0.x",
+    "react-dom": "15.0.x"
   }
 }


### PR DESCRIPTION
Bumped the react version in package.json to support react v15

For the time being I am maintaining :-
https://github.com/divyenduz/react-google-publisher-tag

As soon as this repository starts supporting react v15. I will delete mine.

Thanks 
