### PR TITLE
Pass collapseEmptyDiv options to specific slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,20 @@ module.exports = React.createClass({
 
 ## Parameters
 
-| Name           |     Type  |  Required | Default   |
-|----------------------------|-----------|-----------|------------|
-| path                       | String    | true      |            |
-| responsive                 | Boolean   | true      | true       |
-| format                     | String    | true      | HORIZONTAL |
-| canBeLower                 | Boolean   | true      | true       |
-| dimensions                 | Array     | false     |            |
-| minWindowWidth             | Integer   | false     | -1         |
-| maxWindowWidth             | Integer   | false     | -1         |
-| className                  | String    | false     |            |
-| targeting                  | Object    | false     |            |
-| slotRenderedCallback       | Function  | false     |            |
-| impressionViewableCallback | Function  | false     |            |
+| Name                       |     Type         |  Required | Default   |
+|----------------------------|------------------|-----------|------------|
+| path                       | String           | true      |            |
+| responsive                 | Boolean          | true      | true       |
+| format                     | String           | true      | HORIZONTAL |
+| canBeLower                 | Boolean          | true      | true       |
+| dimensions                 | Array            | false     |            |
+| minWindowWidth             | Integer          | false     | -1         |
+| maxWindowWidth             | Integer          | false     | -1         |
+| className                  | String           | false     |            |
+| targeting                  | Object           | false     |            |
+| slotRenderedCallback       | Function         | false     |            |
+| impressionViewableCallback | Function         | false     |            |
+| collapseEmptyDiv           | boolean or Array | false     |            |
 
 ## Path
 
@@ -137,6 +138,15 @@ Pass a function that will be executed when the slot is rendered.
 ## impressionViewableCallback
 
 Pass a function that will be executed when the ad is fully rendered.
+
+## CollapseEmptyDiv
+
+Define the collapsing behaviour of empty slots for a specific slots (default it set to true).
+| Behaviour                         | Argument     |
+|-----------------------------------|--------------|
+| Don't collapse the slot at all    | false        |
+| Collapse the slot before fetching | [true, true] |
+| Collapse the slot after fetching  | true         |
 
 ## Credits
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -183,7 +183,7 @@ export default class GooglePublisherTag extends Component {
 
     // filter by min and max width
     const windowWidth = window.innerWidth;
-    const { minWindowWidth, maxWindowWidth, targeting } = props;
+    const { minWindowWidth, maxWindowWidth, targeting, collapseEmptyDiv } = props;
 
     if (minWindowWidth !== -1 && minWindowWidth < windowWidth) {
       dimensions = [];
@@ -226,6 +226,14 @@ export default class GooglePublisherTag extends Component {
       forOwn(targeting, (value, key) => {
         slot.setTargeting(key, value);
       });
+    }
+
+    if (typeof collapseEmptyDiv !== 'undefined') {
+      if (Array.isArray(collapseEmptyDiv)) {
+        slot.setCollapseEmptyDiv.apply('setCollapseEmptyDiv', collapseEmptyDiv);
+      } else {
+        slot.setCollapseEmptyDiv(collapseEmptyDiv);
+      }
     }
 
     slot.addService(googletag.pubads());


### PR DESCRIPTION
By collapsing the div before fetching the slot by setting collapseEmptyDiv to `[true, true]`, the slot is expanded when the size is known. Setting it to `false` prevents collapsing and thus jumping content in some cases. Maybe this is also interesting for you :)
