### PR TITLE
Recreate ad if targeting changed

### DIFF
--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -190,12 +190,11 @@ export default class GooglePublisherTag extends Component {
     }
 
     // do nothink
-    if (JSON.stringify(dimensions) === JSON.stringify(this.currentDimensions)) {
+    if (JSON.stringify(props.targeting) === JSON.stringify(this.props.targeting) && JSON.stringify(dimensions) === JSON.stringify(this.currentDimensions)) {
       return;
     }
 
     this.currentDimensions = dimensions;
-
 
     if (this.slot) {
       // remove current slot because dimensions is changed and current slot is old

--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -196,6 +196,7 @@ export default class GooglePublisherTag extends Component {
 
     this.currentDimensions = dimensions;
 
+
     if (this.slot) {
       // remove current slot because dimensions is changed and current slot is old
       this.removeSlot();


### PR DESCRIPTION
Hi,

Currently using your GPT but it would not update the ads unit if targeting changes in our SPA.

This change would check if targeting is the same or different along with the check for dimensions.

Thanks!