### PR TITLE
Add props event callback to fire when slot visibility changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ module.exports = React.createClass({
 | targeting                  | Object           | false     |            |
 | onSlotRenderEnded          | Function         | false     |            |
 | onImpressionViewable       | Function         | false     |            |
+| onSlotVisibilityChanged    | Function         | false     |            |
 | collapseEmptyDiv           | boolean or Array | false     |            |
 
 ## Path
@@ -143,6 +144,10 @@ Pass a function that will be executed when the slot is rendered.
 ## onImpressionViewable
 
 Pass a function that will be executed when the ad is fully rendered.
+
+## onImpressionViewable
+
+Pass a function that will be executed when the on-screen percentage of an ad area changes
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Pass a function that will be executed when the slot is rendered.
 
 Pass a function that will be executed when the ad is fully rendered.
 
-## onImpressionViewable
+## onSlotVisibilityChanged
 
 Pass a function that will be executed when the on-screen percentage of an ad area changes
 

--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -58,7 +58,7 @@ function initGooglePublisherTag(props) {
     googletag.cmd = googletag.cmd || [];
   }
 
-  const { onImpressionViewable, onSlotRenderEnded, path } = props;
+  const { onImpressionViewable, onSlotRenderEnded, onSlotVisibilityChanged, path } = props;
 
   // Execute callback when the slot is visible in DOM (thrown before 'impressionViewable' )
   if (onSlotRenderEnded) {
@@ -79,6 +79,17 @@ function initGooglePublisherTag(props) {
       googletag.pubads().addEventListener('impressionViewable', (event) => {
         if (event.slot.getAdUnitPath() === path) {
           onImpressionViewable(event);
+        }
+      });
+    });
+  }
+
+  // Execute callback whenever the on-screen percentage of an ad slot's area changes
+  if (onSlotVisibilityChanged) {
+    googletag.cmd.push(() => {
+      googletag.pubads().addEventListener('slotVisibilityChanged', (event) => {
+        if (event.slot.getAdUnitPath() === path) {
+          onSlotVisibilityChanged(event);
         }
       });
     });
@@ -124,6 +135,7 @@ export default class GooglePublisherTag extends Component {
     targeting: PropTypes.object,
     resizeDebounce: PropTypes.number.isRequired,
     onSlotRenderEnded: PropTypes.func,
+    onSlotVisibilityChanged: PropTypes.func,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Add props event callback to fire when slot visibility changed. This event is fired whenever the on-screen percentage of an ad slot's area changes.