### PR TITLE
Add support for out-of-page slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,19 @@ It will setup ad size automatically for this component:
  - 336x280: [[336, 280], [300, 250]]
  - 728x90: [[728, 90], [468, 60]]
  - 970x90: [[970, 90], [728, 90], [468, 60]]
+ - OUT_OF_PAGE: none
+
 
 Instead of format you can set your own dimmensions. More details you can find in the [adsense documentation](https://support.google.com/adsense/answer/6002621?hl=sk)
 
 ## Can be lower
 
 You can allow lower ad size automatically. (Default: true)
+
+## out-of-page
+
+Provide format=Format.OUT_OF_PAGE for an Out of Page slot with no dimensions.
+More info: [GPT out-of-page](https://developers.google.com/doubleclick-gpt/reference#googletag.defineOutOfPageSlot)
 
 ## Targeting
 

--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -183,6 +183,7 @@ export default class GooglePublisherTag extends Component {
       return;
     }
 
+    const isOutOfPage = props.format === Format.OUT_OF_PAGE;
     const componentWidth = node.offsetWidth;
     const availableDimensions = prepareDimensions(props.dimensions, props.format, props.canBeLower);
 
@@ -215,7 +216,7 @@ export default class GooglePublisherTag extends Component {
     }
 
     // there is nothink to display
-    if (!dimensions || !dimensions.length) {
+    if (!isOutOfPage && (!dimensions || !dimensions.length)) {
       return;
     }
 
@@ -224,7 +225,9 @@ export default class GooglePublisherTag extends Component {
     node.innerHTML = `<div id="${id}"></div>`;
 
     // prepare new slot
-    const slot = googletag.defineSlot(props.path, dimensions, id);
+    const slot = isOutOfPage 
+      ? googletag.defineOutOfPageSlot(props.path, id)
+      : googletag.defineSlot(props.path, dimensions, id);
     this.slot = slot;
 
     // set targeting

--- a/src/constants/Format.js
+++ b/src/constants/Format.js
@@ -9,4 +9,5 @@ export default keymirror({
   MOBILE_HORIZONTAL: null,
   PORTRET: null,
   BILBORD: null,
+  OUT_OF_PAGE: null,
 });


### PR DESCRIPTION
Thanks for publishing this package. I needed support for an out-of-page slot in my project. I chose to make it a format but I can change it to another parameter if you prefer. When a slot is out-of-page there are no dimensions so I had to bypass the early return requiring dimensions.