### PR TITLE
Destroy slots with custom ids before recreating them

### DIFF
--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -124,6 +124,7 @@ function initGooglePublisherTag(props) {
 export default class GooglePublisherTag extends Component {
   static propTypes = {
     className: PropTypes.string,
+    id: PropTypes.string,
     path: PropTypes.string.isRequired,
     format: PropTypes.string.isRequired,
     responsive: PropTypes.bool.isRequired,
@@ -253,6 +254,10 @@ export default class GooglePublisherTag extends Component {
   removeSlot() {
     if (!this.slot) {
       return;
+    }
+
+    if (this.props.id) {
+      googletag.destroySlots([this.slot]);
     }
 
     googletag.pubads().clear([this.slot]);

--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -256,11 +256,7 @@ export default class GooglePublisherTag extends Component {
       return;
     }
 
-    if (this.props.id) {
-      googletag.destroySlots([this.slot]);
-    }
-
-    googletag.pubads().clear([this.slot]);
+    googletag.destroySlots([this.slot]);
     this.slot = null;
 
     if (this.node) {


### PR DESCRIPTION
`googletag.defineSlot()` returns null if it's invoked more than one time with the same id and the previous slot is not destroyed. It causes runtime errors when custom ids are used. This PR fixes that problem.