### PR TITLE
Allow to use a custom slot refresher

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ module.exports = React.createClass({
 
 ## Parameters
 
-| Name                       |     Type         |  Required | Default   |
+| Name                       |     Type         |  Required | Default    |
 |----------------------------|------------------|-----------|------------|
 | path                       | String           | true      |            |
 | responsive                 | Boolean          | true      | true       |
@@ -82,6 +82,7 @@ module.exports = React.createClass({
 | onImpressionViewable       | Function         | false     |            |
 | onSlotVisibilityChanged    | Function         | false     |            |
 | collapseEmptyDiv           | boolean or Array | false     |            |
+| slotRefresher              | Function         | false     |            |
 
 ## Path
 
@@ -148,6 +149,10 @@ Pass a function that will be executed when the ad is fully rendered.
 ## onSlotVisibilityChanged
 
 Pass a function that will be executed when the on-screen percentage of an ad area changes
+
+## slotRefresher
+
+Pass a function that will be used for refreshing slots. By default `googletag.pubads().refresh()` is used.
 
 ## Credits
 

--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -137,6 +137,7 @@ export default class GooglePublisherTag extends Component {
     resizeDebounce: PropTypes.number.isRequired,
     onSlotRenderEnded: PropTypes.func,
     onSlotVisibilityChanged: PropTypes.func,
+    slotRefresher: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -146,6 +147,7 @@ export default class GooglePublisherTag extends Component {
     enableSingleRequest: false,
     dimensions: null,
     resizeDebounce: 100,
+    slotRefresher: slot => googletag.pubads().refresh([slot]),
   };
 
   componentDidMount() {
@@ -248,7 +250,7 @@ export default class GooglePublisherTag extends Component {
 
     // display new slot
     googletag.display(id);
-    googletag.pubads().refresh([slot]);
+    this.props.slotRefresher(slot);
   }
 
   removeSlot() {
@@ -266,7 +268,7 @@ export default class GooglePublisherTag extends Component {
 
   refreshSlot() {
     if (this.slot) {
-      googletag.pubads().refresh([this.slot]);
+      this.props.slotRefresher(this.slot);
     }
   }
 


### PR DESCRIPTION
We're using a yield optimizer which requires us to use a proprietary function for refreshing slot instead of `googletag.pubads().refresh()` (for header bidding etc.). This PR allows that by specifying the `slotRefresher` property. `googletag.pubads().refresh()` is still used as the default one.