### PR TITLE
Added UNSAFE flag to deprecated component lifecycle methods

### DIFF
--- a/src/GooglePublisherTag.jsx
+++ b/src/GooglePublisherTag.jsx
@@ -258,7 +258,7 @@ export default class GooglePublisherTag extends PureComponent<Props, State> {
     });
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     this.update(props);
   }
 


### PR DESCRIPTION
After react 16.9 update, a warning is being thrown if unsafe component lifecycle methods are used without UNSAFE_ flag. Added the flag to suppress the warning.